### PR TITLE
Simplify and speed up the charts component

### DIFF
--- a/google-chart.component.ts
+++ b/google-chart.component.ts
@@ -13,23 +13,18 @@ export class GoogleChartComponent implements OnInit {
     this._element = this.element.nativeElement;
   }
   ngOnInit() {
-    setTimeout(() =>{
-      google.charts.load('current', {'packages':['corechart']});
-        setTimeout(() =>{
-          this.drawGraph(this.chartOptions,this.chartType,this.chartData,this._element)
-        },1000);
-      },1000
-    );
+    google.charts.load('current', {'packages':['corechart']});
+    google.charts.setOnLoadCallback(this.drawGraph);
   }
-  drawGraph (chartOptions,chartType,chartData,ele) {
-    google.charts.setOnLoadCallback(drawChart);
+  drawGraph = () => {
+    
     function drawChart() {
       var wrapper;
       wrapper = new google.visualization.ChartWrapper({
-        chartType: chartType,
-        dataTable:chartData ,
-        options:chartOptions || {},
-        containerId: ele.id
+        chartType: this.chartType,
+        dataTable:this.chartData ,
+        options: this.chartOptions || {},
+        containerId: this._element.id
       });
       wrapper.draw();
     }


### PR DESCRIPTION
Thanks a ton for your work, it helped form the basis of how I integrated Google charts into my angular application!

I noticed that you use an arrow => from ECMAScript 2015 in your component. You can actually use arrow functions to get rid of timeouts all together. Turn drawGraph into an arrow function. The "lexical this" property of arrow functions will keep "this" bound to your class, even when the code is executed as a callback. That way you don't have to use setTimeout and introduce more delays than necessary.